### PR TITLE
🤖 chore: add CODEOWNERS gating Cloud Build files to @vendasta/sre

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# SRE owned files
+/cloudbuild.yaml         @vendasta/sre
+/cloudbuild-*.yaml       @vendasta/sre
+/build/                  @vendasta/sre


### PR DESCRIPTION
Adds @vendasta/sre as CodeOwner for `cloudbuild*.yaml` and `/build/`.

**What this PR actually does on its own:** notification only. SRE gets auto-requested as a reviewer whenever those files change, so we can sanity-check things like the container image being pulled. No merge block, no required approval. Devs can still ship without our blessing.

**Caveat:** if this repo already has "Require review from Code Owners" enabled in branch protection, then this PR will make SRE approval *required* for the listed paths under that existing setting. We are not changing that toggle in this PR.

If the repo already had a CODEOWNERS file, the SRE block was appended preserving existing rules. Under GitHub's last-match-wins, SRE rules take precedence for the listed paths.

@vendasta/sre [VSRE-3146]


[VSRE-3146]: https://vendasta.jira.com/browse/VSRE-3146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ